### PR TITLE
Add Playwright test for Wellness submenu links and locator file

### DIFF
--- a/sohohousehomepagelocators.py
+++ b/sohohousehomepagelocators.py
@@ -1,0 +1,2 @@
+WELLNESS_MENU_LINK = "a:has-text('Wellness')"
+WELLNESS_SUBMENU_LINKS = "nav[role='navigation'] a"  # Adjusted after inspecting submenu structure

--- a/testsohohousehomepage.py
+++ b/testsohohousehomepage.py
@@ -1,0 +1,23 @@
+from playwright.sync_api import sync_playwright
+from sohohousehomepagelocators import WELLNESS_MENU_LINK, WELLNESS_SUBMENU_LINKS
+
+def test_fetch_wellness_submenu_links():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+        page = browser.new_page()
+        page.goto("https://www.sohohouse.com/")
+        # Click on the 'Wellness' top menu link
+        page.click(WELLNESS_MENU_LINK)
+
+        # Wait for submenu to appear (adjust selector as needed)
+        page.wait_for_selector(WELLNESS_SUBMENU_LINKS)
+
+        # Fetch all submenu link names under 'Wellness'
+        submenu_links = page.query_selector_all(WELLNESS_SUBMENU_LINKS)
+        submenu_names = [link.inner_text() for link in submenu_links]
+
+        print("Submenu links under 'Wellness':")
+        for name in submenu_names:
+            print(name)
+
+        browser.close()


### PR DESCRIPTION
- Added locator file `sohohousehomepagelocators.py` with selectors for Wellness menu and submenu.
- Added test script `testsohohousehomepage.py` to fetch and print all submenu links under the Wellness menu on sohohouse.com.

This PR introduces Playwright-based automation for validating the Wellness navigation structure.