### PR TITLE
Add Playwright test for Wellness menu and submenu on Soho House

### DIFF
--- a/locators/home_page_locators.py
+++ b/locators/home_page_locators.py
@@ -1,0 +1,10 @@
+# locators/home_page_locators.py
+
+from playwright.sync_api import Page, Locator
+
+def get_wellness_menu_locator(page: Page) -> Locator:
+    return page.locator('a:has-text("Wellness")')
+
+def get_wellness_submenu_locator(page: Page) -> Locator:
+    # Adjust selector as needed based on actual submenu DOM
+    return page.locator('nav[aria-label="Wellness submenu"]')

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -1,0 +1,23 @@
+# tests/test_home_page.py
+
+import pytest
+from playwright.sync_api import sync_playwright
+from locators.home_page_locators import get_wellness_menu_locator, get_wellness_submenu_locator
+
+def test_wellness_menu_submenu():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto("https://www.sohohouse.com/en-us/")
+        page.wait_for_load_state('networkidle')
+
+        # Click on the "Wellness" top menu link
+        wellness_menu = get_wellness_menu_locator(page)
+        wellness_menu.click()
+
+        # Capture the submenu of the Wellness menu
+        submenu = get_wellness_submenu_locator(page)
+        assert submenu.is_visible(), "Wellness submenu should be visible after clicking Wellness menu."
+        print("Submenu text:", submenu.inner_text())
+
+        browser.close()


### PR DESCRIPTION
- Added locators/home_page_locators.py for menu and submenu selectors.
- Added tests/test_home_page.py with a test that navigates to the homepage, clicks the Wellness menu, and asserts the submenu is visible.

This implements the requested UI automation steps for the Soho House homepage.
