### PR TITLE
Playwright E2E: Wellness menu submenu extraction test

### DIFF
--- a/locators/home_page_locators.py
+++ b/locators/home_page_locators.py
@@ -1,0 +1,7 @@
+# locators/home_page_locators.py
+
+from playwright.sync_api import Page, Locator
+
+class HomePageLocators:
+    WELLNESS_MENU = "a[data-testid='nav-link-wellness']"
+    WELLNESS_SUBMENUS = "[data-testid='nav-link-wellness'] + div ul li a"  # Adjust if actual DOM differs

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -1,0 +1,21 @@
+# tests/test_home_page.py
+
+import pytest
+from playwright.sync_api import sync_playwright
+from locators.home_page_locators import HomePageLocators
+
+BASE_URL = "https://www.sohohouse.com/en-us/"
+
+@pytest.mark.e2e
+def test_wellness_menu_submenus():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto(BASE_URL)
+        # Click on the "Wellness" top menu link
+        page.click(HomePageLocators.WELLNESS_MENU)
+        # Fetch the names of all the submenus under Wellness
+        submenu_elements = page.query_selector_all(HomePageLocators.WELLNESS_SUBMENUS)
+        submenu_names = [el.inner_text().strip() for el in submenu_elements]
+        print("Submenu names under Wellness:", submenu_names)
+        browser.close()


### PR DESCRIPTION
This PR adds Playwright-based E2E automation for the following scenario:
- Navigates to https://www.sohohouse.com/en-us/
- Clicks the "Wellness" top menu link
- Extracts and prints all submenu names under Wellness

Files added:
- locators/home_page_locators.py
- tests/test_home_page.py

Implements orchestrated pipeline step 1 for UI automation.