### PR TITLE
Playwright E2E: Wellness menu submenu extraction test

### DIFF
--- a/locators/home_page_locators.py
+++ b/locators/home_page_locators.py
@@ -1,0 +1,4 @@
+# locators/home_page_locators.py
+
+WELLNESS_MENU = "a[data-testid='top-menu-link'][href*='wellness']"
+WELLNESS_SUBMENUS = "nav[aria-label='Wellness'] ul li a, nav[aria-label='Wellness'] ul li button"

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -1,0 +1,19 @@
+# tests/test_home_page.py
+
+from playwright.sync_api import sync_playwright
+from locators.home_page_locators import WELLNESS_MENU, WELLNESS_SUBMENUS
+
+def test_wellness_menu_submenus():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto("https://www.sohohouse.com/en-us/")
+        page.click(WELLNESS_MENU)
+        page.wait_for_selector(WELLNESS_SUBMENUS, timeout=5000)
+        submenu_elements = page.query_selector_all(WELLNESS_SUBMENUS)
+        submenu_names = [el.inner_text().strip() for el in submenu_elements]
+        print("Wellness Submenus:", submenu_names)
+        browser.close()
+
+if __name__ == "__main__":
+    test_wellness_menu_submenus()


### PR DESCRIPTION
This PR adds Playwright-based Python automation to:
- Open https://www.sohohouse.com/en-us/
- Click the "Wellness" top menu link
- Fetch and print all submenu names under the Wellness menu
- Close the browser

Files added:
- locators/home_page_locators.py (locator definitions)
- tests/test_home_page.py (test script)

Implements the orchestrated pipeline step for UI automation as described.