### PR TITLE
Playwright Test: Book Menu Submenus Extraction

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests/__init__.py

--- a/tests/test_book_menu.py
+++ b/tests/test_book_menu.py
@@ -1,0 +1,18 @@
+# tests/test_book_menu.py
+
+import pytest
+from playwright.sync_api import sync_playwright
+from locators.home_page_locators import BOOK_MENU_LINK, BOOK_SUBMENU_ITEMS
+
+URL = "https://www.sohohouse.com/en-us/"
+
+def test_book_menu_submenus():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto(URL)
+        page.click(BOOK_MENU_LINK)
+        submenu_elements = page.query_selector_all(BOOK_SUBMENU_ITEMS)
+        submenu_names = [el.inner_text().strip() for el in submenu_elements]
+        print("Book submenu names:", submenu_names)
+        browser.close()


### PR DESCRIPTION
This PR adds a Playwright-based Python test to automate the following UI flow for https://www.sohohouse.com/en-us/:

- Navigates to the homepage
- Clicks the top menu link "Book"
- Fetches and prints the names of all submenus under the Book menu
- Closes the browser

Files added/updated:
- locators/home_page_locators.py (locators for Book menu)
- tests/test_book_menu.py (test script)
- locators/__init__.py
- tests/__init__.py

This follows Python package conventions and organizes code for maintainability.