### PR TITLE
Playwright Test: Bedrooms Menu Submenu Extraction

### DIFF
--- a/locators/home_page_locators.py
+++ b/locators/home_page_locators.py
@@ -2,3 +2,6 @@
 
 WELLNESS_MENU = "a[data-testid='top-menu-link'][href*='wellness']"
 WELLNESS_SUBMENUS = "nav[aria-label='Wellness'] ul li a, nav[aria-label='Wellness'] ul li button"
+
+BEDROOMS_MENU = "a[data-testid='nav-link-bedrooms']"
+BEDROOMS_SUBMENU_ITEMS = "ul[data-testid='bedrooms-submenu'] li a"

--- a/tests/test_bedrooms_menu.py
+++ b/tests/test_bedrooms_menu.py
@@ -1,0 +1,16 @@
+# tests/test_bedrooms_menu.py
+
+from playwright.sync_api import sync_playwright
+from locators.home_page_locators import BEDROOMS_MENU, BEDROOMS_SUBMENU_ITEMS
+
+def test_bedrooms_submenus():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto("https://www.sohohouse.com/en-us/")
+        page.click(BEDROOMS_MENU)
+        page.wait_for_selector(BEDROOMS_SUBMENU_ITEMS)
+        submenu_elements = page.query_selector_all(BEDROOMS_SUBMENU_ITEMS)
+        submenu_names = [el.inner_text() for el in submenu_elements]
+        print("Submenus under 'Bedrooms':", submenu_names)
+        browser.close()


### PR DESCRIPTION
This PR adds a Playwright-based Python test to:
- Navigate to https://www.sohohouse.com/en-us/
- Click the 'Bedrooms' menu
- Fetch and print all submenu names under 'Bedrooms'

Locator definitions for the Bedrooms menu and its submenus are added to locators/home_page_locators.py.

Test script is added at tests/test_bedrooms_menu.py.

Closes automation pipeline step for UI navigation and submenu extraction.